### PR TITLE
#167249756 add feature to enable user add seats on booking

### DIFF
--- a/server/controllers/bookings/createBooking.js
+++ b/server/controllers/bookings/createBooking.js
@@ -1,7 +1,10 @@
 import jwt from 'jsonwebtoken';
+import Joi from '@hapi/joi';
 import uuid from 'uuid';
 import resPonse from '../../helpers/responses/response';
 import Book from '../../models/bookings';
+import bookingSchema from '../../helpers/schema/booking';
+
 
 const createBooking = (req, res) => {
 /*
@@ -18,17 +21,25 @@ const createBooking = (req, res) => {
     getUser.lastName,
     getUser.email,
   );
-  const foundBus = Book.checkIfTripExists(bookData.busLicenseNumber);
-  const foundDate = Book.checkIfTripDateIsValid(bookData.tripDate);
-  if (foundBus) {
-    if (foundDate) {
-      Book.createNewBooking(bookData);
-      const data = bookData;
-      return resPonse.successData(res, 201, data);
-    } resPonse.errorMessage(res, 400, `No trip is available on this date ${tripDate}`);
-  } else {
-    resPonse.errorMessage(res, 400, `Bus license number ${busLicenseNumber} doesnt exist`);
-  }
+  const inputData = req.body;
+  const schema = bookingSchema(Joi);
+  Joi.validate(inputData, schema, (error) => {
+    if (error) {
+      return resPonse.errorMessage(res, 400, (error.details[0].message));
+    }
+    const foundBus = Book.checkIfTripExists(bookData.busLicenseNumber);
+    const foundDate = Book.checkIfTripDateIsValid(bookData.tripDate);
+    if (foundBus) {
+      if (foundDate) {
+        Book.createNewBooking(bookData);
+        const data = bookData;
+        return resPonse.successData(res, 201, data);
+      } resPonse.errorMessage(res, 400, `No trip is available on this date ${tripDate}`);
+    } else {
+      return resPonse.errorMessage(res, 400, `Bus license number ${busLicenseNumber} doesnt exist`);
+    }
+    return true;
+  });
   return true;
 };
 

--- a/server/controllers/bookings/createBooking.js
+++ b/server/controllers/bookings/createBooking.js
@@ -12,11 +12,12 @@ const createBooking = (req, res) => {
  - match the user with token
 */
   const getUser = jwt.decode(req.headers.authorization);
-  const { busLicenseNumber, tripDate } = req.body;
+  const { busLicenseNumber, tripDate, numberOfSeats } = req.body;
   const bookData = Book.bookindModel(
     uuid.v4(),
     busLicenseNumber,
     tripDate,
+    numberOfSeats,
     getUser.firstName,
     getUser.lastName,
     getUser.email,

--- a/server/helpers/schema/booking.js
+++ b/server/helpers/schema/booking.js
@@ -6,6 +6,8 @@ const JoiD = BaseJoi.extend(Extension);
 const bookingSchema = Joi => Joi.object().keys({
   busLicenseNumber: Joi.string().alphanum().min(3).max(30)
     .required(),
+  numberOfSeats: Joi.number().min(1).max(30)
+    .required(),
   tripDate: JoiD.date().format('MM-MM-YYYY').required(),
 });
 

--- a/server/helpers/schema/booking.js
+++ b/server/helpers/schema/booking.js
@@ -1,0 +1,12 @@
+const BaseJoi = require('@hapi/joi');
+const Extension = require('@hapi/joi-date');
+
+const JoiD = BaseJoi.extend(Extension);
+
+const bookingSchema = Joi => Joi.object().keys({
+  busLicenseNumber: Joi.string().alphanum().min(3).max(30)
+    .required(),
+  tripDate: JoiD.date().format('MM-MM-YYYY').required(),
+});
+
+module.exports = bookingSchema;

--- a/server/helpers/schema/trip.js
+++ b/server/helpers/schema/trip.js
@@ -10,7 +10,7 @@ const trip = () => Joi => Joi.object().keys({
   origin: Joi.string().alphanum().required()
     .regex(/^[a-zA-Z0-9!@#$%&*]{3,25}$/),
   destination: Joi.string().alphanum().required(),
-  tripDate: JoiD.date().format('YYYY-MM-DD'),
+  tripDate: JoiD.date().format('MM-MM-YYYY'),
   fare: Joi.number().min(5).required(),
 });
 

--- a/server/tests/bookings.test.js
+++ b/server/tests/bookings.test.js
@@ -8,6 +8,7 @@ chai.use(chaiHttp);
 const bookingData = {
   busLicenseNumber: 'UAG34',
   tripDate: '23-12-2019',
+  numberOfSeats: 3,
 };
 
 const user = {
@@ -74,6 +75,7 @@ describe('BOOKINGS TESTS', () => {
       .send({
         busLicenseNumber: 'UAG34223',
         tripDate: '23-12-2019',
+        numberOfSeats: 3,
       })
       .end((err, res) => {
         expect(res).to.have.status(400);
@@ -99,6 +101,7 @@ describe('BOOKINGS TESTS', () => {
       .send({
         busLicenseNumber: 'UAG34',
         tripDate: '13-12-2019',
+        numberOfSeats: 3,
       })
       .end((err, res) => {
         expect(res).to.have.status(400);

--- a/server/tests/bookings.test.js
+++ b/server/tests/bookings.test.js
@@ -7,7 +7,7 @@ chai.use(chaiHttp);
 
 const bookingData = {
   busLicenseNumber: 'UAG34',
-  tripDate: '2019-12-23',
+  tripDate: '23-12-2019',
 };
 
 const user = {
@@ -22,7 +22,7 @@ const tripData = {
   busLicenseNumber: 'UAG34',
   origin: 'kampala',
   destination: 'kigali',
-  tripDate: '2019-12-23',
+  tripDate: '23-12-2019',
   fare: 20000,
 };
 
@@ -73,7 +73,19 @@ describe('BOOKINGS TESTS', () => {
       .set('Authorization', userToken)
       .send({
         busLicenseNumber: 'UAG34223',
-        tripDate: '2019-12-23',
+        tripDate: '23-12-2019',
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        done();
+      });
+  });
+  it('should return error if a field is missing', (done) => {
+    chai.request(app)
+      .post('/api/v1/bookings')
+      .set('Authorization', userToken)
+      .send({
+        busLicenseNumber: 'UAG34223',
       })
       .end((err, res) => {
         expect(res).to.have.status(400);
@@ -86,7 +98,7 @@ describe('BOOKINGS TESTS', () => {
       .set('Authorization', userToken)
       .send({
         busLicenseNumber: 'UAG34',
-        tripDate: '2019-12-01',
+        tripDate: '13-12-2019',
       })
       .end((err, res) => {
         expect(res).to.have.status(400);

--- a/server/tests/trips.test.js
+++ b/server/tests/trips.test.js
@@ -26,7 +26,7 @@ const tripData = {
   busLicenseNumber: 'UGXHD',
   origin: 'kampala',
   destination: 'kigali',
-  tripDate: '2019-12-23',
+  tripDate: '23-12-2019',
   fare: 20000,
 };
 before((done) => {


### PR DESCRIPTION
#### What does this PR do?
adds a feature to enable the user to add seats on booking

#### Description of Task to be completed
Users can specify their seat numbers when making a booking.

#### How should this be manually tested?
- After signing in
- send `POST` -  data ` {
  busLicenseNumber: 'UAG34',
  tripDate: '2019-12-23',
  numberOfSeats: 2,
};` to https://way-fare.herokuapp.com/api/v1/bookings


#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/167249756