### PR TITLE
#167248385 add a feature to get all bookings by a user and admin

### DIFF
--- a/server/controllers/bookings/getAllBookings.js
+++ b/server/controllers/bookings/getAllBookings.js
@@ -1,0 +1,22 @@
+import jwt from 'jsonwebtoken';
+import resPonse from '../../helpers/responses/response';
+import Book from '../../models/bookings';
+
+const getAllBookings = (req, res) => {
+  try {
+    const getUser = jwt.decode(req.headers.authorization);
+    if (getUser.isAdmin === true) {
+      const allBookings = Book.bookingDatabase;
+      if (allBookings.length === 0) {
+        return resPonse.errorMessage(res, 200, 'No bookings made at the moment');
+      } resPonse.successData(res, 200, allBookings);
+    }
+    const forUser = Book.getUserBookings(getUser.id);
+    if (forUser.length === 0) {
+      return resPonse.errorMessage(res, 200, 'You have made no bookings yet');
+    } resPonse.successData(res, 200, forUser);
+  // eslint-disable-next-line no-empty
+  } catch (error) {}
+  return true;
+};
+module.exports = getAllBookings;

--- a/server/models/bookings.js
+++ b/server/models/bookings.js
@@ -2,7 +2,6 @@ import Trip from './trips';
 
 const bookingDatabase = [];
 const newTrip = Trip;
-
 const Book = {
   bookingDatabase,
   bookindModel(bookingId, userId, busLicenseNumber,
@@ -39,6 +38,9 @@ const Book = {
   },
   checkBookingUser(userid) {
     return bookingDatabase.find(x => x.userId === userid);
+  },
+  getUserBookings(userid) {
+    return bookingDatabase.filter(x => x.userId === userid);
   },
   findBooking(bookid) {
     return bookingDatabase.find(x => x.bookingId === bookid);

--- a/server/routes/bookings/bookingRouter.js
+++ b/server/routes/bookings/bookingRouter.js
@@ -1,11 +1,14 @@
 import express from 'express';
 import createBooking from '../../controllers/bookings/createBooking';
 import deleteBooking from '../../controllers/bookings/deleteBooking';
+import getAllBookings from '../../controllers/bookings/getAllBookings';
+
 
 import appAuth from '../../middleware/appAuth';
 
 const bookingRouter = express.Router();
 bookingRouter.post('/bookings', appAuth, createBooking);
+bookingRouter.get('/bookings', appAuth, getAllBookings);
 bookingRouter.delete('/bookings/:bookingId', appAuth, deleteBooking);
 
 

--- a/server/tests/bookings.test.js
+++ b/server/tests/bookings.test.js
@@ -94,10 +94,37 @@ before((done) => {
       done();
     });
 });
+before((done) => {
+  chai.request(app)
+    .get('/api/v1/bookings')
+    .set('Authorization', otherUserToken)
+    .end((err, res) => {
+      expect(res).to.have.status(200);
+      done();
+    });
+});
+before((done) => {
+  chai.request(app)
+    .get('/api/v1/bookings')
+    .set('Authorization', userToken)
+    .end((err, res) => {
+      expect(res).to.have.status(200);
+      done();
+    });
+});
 describe('BOOKINGS TESTS', () => {
   it('should delete a booking', (done) => {
     chai.request(app)
       .delete(`/api/v1/bookings/${bookingId}`)
+      .set('Authorization', userToken)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        done();
+      });
+  });
+  it('should return an array of bookings', (done) => {
+    chai.request(app)
+      .get('/api/v1/bookings')
       .set('Authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);


### PR DESCRIPTION
#### What does this PR do?
adds a feature to get all bookings by a user and admin for all users

#### Description of Task to be completed
View all bookings. An Admin can see all bookings, while the user can see all of his/her
bookings

#### How should this be manually tested?
- After **signing in**, send `GET` to https://way-fare.herokuapp.com/api/v1/bookings

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/167248385